### PR TITLE
Move graphql to peerDependencies in CLI

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -50,13 +50,15 @@
         "sucrase": "^3.12.1",
         "ts-jest": "^23.10.5"
     },
+    "peerDependencies": {
+        "graphql": "*"
+    },
     "dependencies": {
         "@genql/runtime": "^2.10.0",
         "@graphql-tools/graphql-file-loader": "^6.0.10",
         "@graphql-tools/load": "^6.0.10",
         "chalk": "^4.1.0",
         "fs-extra": "^9.0.1",
-        "graphql": "*",
         "isomorphic-unfetch": "^3.0.0",
         "listr": "^0.14.3",
         "lodash": "^4.17.20",


### PR DESCRIPTION
Hello! I am opening this PR because I tried installing the CLI on my project and got an error:

```
Cannot generate, got an error:
Error: Cannot use GraphQLObjectType "Query" from another module or realm.

Ensure that there is only one instance of "graphql" in the node_modules
directory. If different versions of "graphql" are the dependencies of other
relied on modules, use "resolutions" to ensure only one version is installed.
```

Although my local version is `16.4.0`, this is installing `15.8.0`, which is raising the error.

Also, the `@genql/runtime` package has it as a peer dependency, so both packages will be more concise.