### PR TITLE
Fix: pass custom subscription options

### DIFF
--- a/runtime/src/client/createClient.ts
+++ b/runtime/src/client/createClient.ts
@@ -146,7 +146,7 @@ const mapResponse = (path: string[], defaultValue: any = undefined) => (
 }
 
 function getSubscriptionClient(opts: ClientOptions = {}): WsSubscriptionClient {
-    let { url, headers = {} } = opts.subscription || {}
+    let { url, headers = {}, ...rest } = opts.subscription || {}
     // by default use the top level url
     if (!url) {
         url = opts?.url
@@ -169,7 +169,7 @@ function getSubscriptionClient(opts: ClientOptions = {}): WsSubscriptionClient {
                     headers: headersObject,
                 }
             },
-            ...opts,
+            ...rest,
         },
         typeof window === 'undefined' ? ws : undefined,
     )


### PR DESCRIPTION
Pass options to WsSubscriptionClient

It seems that there is a small mistake with the options, the correct option is to pass not the entire `opts`, but the `opts.subscription`

I faced this issue because I need to adjust contents of `connectionParams` object