### PR TITLE
fix: @genql/runtime is required

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ First generate your client executing
 
 ```sh
 npm i -D @genql/cli # cli to generate the client code
-npm i graphql # runtime dependency
+npm i graphql @genql/runtime # runtime dependencies
 genql --schema ./schema.graphql --output ./generated
 ```
 


### PR DESCRIPTION
The @genql/runtime package is a runtime requirement, however the instructions in the current README does not install it when --no-dev is specified.