### PR TITLE
Fixed a wrong check that prevented the first field of a schema from being registered

### DIFF
--- a/cli/src/runtime/linkTypeMap.ts
+++ b/cli/src/runtime/linkTypeMap.ts
@@ -42,7 +42,7 @@ export const linkTypeMap = (
                             ...Object.keys(fields).map(
                                 (f): PartialLinkedFieldMap => {
                                     const [typeIndex, args] = fields[f] || []
-                                    if (!typeIndex) {
+                                    if (typeIndex === undefined) {
                                         return {}
                                     }
                                     return {


### PR DESCRIPTION
Hey!

Related to #105 
Encountered the same issue today while playing with the new version of GenQL 💖


Here the generated `types.ts` file I had.
```ts
export default {
    "scalars": [
      // ....
    ],
    "types": {
        "Application": {
            "description": [ 223 ],
            "id": [ 457 ],
            "name": [ 223 ],
            "__typename": [ 223 ]
        },
        // ...
```

And when I tried a GenQL query on this field, I got this error: 

`type Query does not have a field Application`

So I investigated and it turns out that the problem come only with this check. Basically `typeIndex` is equal to 0 when it's the first field of the schema. So I replaced it with a check on `undefined` which fixes the problem