### PR TITLE
Add operation name in `generateGraphqlOperation`

### DIFF
--- a/cli/src/runtime/generateGraphqlOperation.ts
+++ b/cli/src/runtime/generateGraphqlOperation.ts
@@ -174,6 +174,7 @@ export const generateGraphqlOperation = (
             },
             {},
         ),
+        ...(operationName ? { operationName: operationName.toString() } : {}),
     }
 }
 


### PR DESCRIPTION
Without this PR : 

```ts
const { query, variables, operationName } = generateQueryOp({
  __name: 'GetApplications',
  application: {
    name: true,
  },
})

console.log(operationName) // Prints `undefined`
```

And we make sure to send `operationName` only when it is set. Otherwise it causes an error when sending the request to a graphql server: it is an optional field in the payload, but if it is defined then the operation must be present in the request.