### PR TITLE
[idea] Allow non-primitive scalars

### DIFF
--- a/cli/src/runtime/typeSelection.ts
+++ b/cli/src/runtime/typeSelection.ts
@@ -86,7 +86,7 @@ type Handle__isUnion<SRC extends Anify<DST>, DST> = SRC extends Nil
     ? never
     : Omit<SRC, FieldsToRemove> // just return the union type
 
-type Scalar = string | number | Date | boolean | null | undefined
+type Scalar = string | number | Date | boolean | null | undefined | { __scalar: true }
 
 type Anify<T> = { [P in keyof T]?: any }
 


### PR DESCRIPTION
Fixes #86 

This is a workaround we're trying (by directly modifying our generated `typesSelection.ts`).

We have a custom scalar type that we want to be queryable in genql. With this change, it's possible to just add a fake property `__scalar: true` (but could be added at runtime too I guess), which serves as a hint to `typeSelection.ts` that it should be included when doing various type-mapping/`extends` checks for scalars.

A change like this should be documented, and should probably also be considered whether it's a good idea to re-use the `__scalar: true` concept from the query building pattern, or something else, but this felt fairly intuitive to me, and solves the problem without adding complicated types.

@remorses what do you think / @boredland would this work in your case too?