### PR TITLE
Fix [fieldSelection]: properly handle nullable fields

### DIFF
--- a/cli/src/runtime/typeSelection.ts
+++ b/cli/src/runtime/typeSelection.ts
@@ -46,10 +46,9 @@ type HandleObject<SRC extends Anify<DST>, DST> = SRC extends Nil
           {
               // using keyof SRC to maintain ?: relations of SRC type
               [Key in keyof SRC]: Key extends keyof DST
-                  ? FieldsSelection<
-                        SRC[Key],
-                        NonNullable<DST[Key]>
-                    >
+                  ? SRC[Key] extends infer NON_NULL_SRC | null
+                  ? FieldsSelection<NON_NULL_SRC, NonNullable<DST[Key]>> | null
+                  : FieldsSelection<SRC[Key], NonNullable<DST[Key]>>
                   : SRC[Key]
           },
           Exclude<keyof DST, FieldsToRemove>

--- a/cli/src/typeSelection.test.ts
+++ b/cli/src/typeSelection.test.ts
@@ -104,16 +104,16 @@ describe('pick', () => {
       a: 1,
       b: 1,
       nested1: {
-        a: 1,
-      },
+        a: 1
+      }
     },
     argumentSyntax: {
       __args: { x: 3 },
       a: 1,
       nesting: {
-        __scalar: 1,
-      },
-    },
+        __scalar: 1
+      }
+    }
   }
   const z: FieldsSelection<SRC, NoExtraProperties<typeof req>> = {} as any
   test(
@@ -125,7 +125,7 @@ describe('pick', () => {
       // @ts-expect-error
       z.category.c
       z.category?.nested1?.a
-    }),
+    })
   )
   test(
     'response type does not have additional properties',
@@ -141,13 +141,13 @@ describe('pick', () => {
       z.category.nested1.c
       // @ts-expect-error
       z.category.nested2
-    }),
+    })
   )
   test(
     'argument syntax',
     dontExecute(() => {
       z.argumentSyntax?.a?.toLocaleLowerCase
-    }),
+    })
   )
 })
 
@@ -157,16 +157,16 @@ describe('__scalar', () => {
     category: {
       __scalar: 1,
       nested1: {
-        a: 1,
-      },
+        a: 1
+      }
     },
     argumentSyntax: {
       __args: { a: 7 },
-      __scalar: 1,
+      __scalar: 1
     },
     argumentScalar: {
-      __args: { x: 9 },
-    },
+      __args: { x: 9 }
+    }
   }
   const z: FieldsSelection<SRC, typeof req> = {} as any
   test(
@@ -179,7 +179,7 @@ describe('__scalar', () => {
       z.category?.nested1.a
       z.category?.a.getDate
       z.category?.b.getDate
-    }),
+    })
   )
   test(
     'response type does not have additional properties',
@@ -193,21 +193,21 @@ describe('__scalar', () => {
       z.category.nested1.c
       // @ts-expect-error
       z.category.nested2
-    }),
+    })
   )
   test(
     '__scalar is not present',
     dontExecute(() => {
       // @ts-expect-error
       z.category.__scalar
-    }),
+    })
   )
   test(
     '__name is not present',
     dontExecute(() => {
       // @ts-expect-error __name
       z.__name
-    }),
+    })
   )
   test(
     'argument syntax',
@@ -216,7 +216,7 @@ describe('__scalar', () => {
       z.argumentSyntax?.optional?.big
       // @ts-expect-error
       z.argumentSyntax.nesting.x
-    }),
+    })
   )
   test(
     'argument syntax on scalar',
@@ -225,7 +225,7 @@ describe('__scalar', () => {
       z.argumentScalar?.charAt
       // @ts-expect-error
       z.argumentScalar.xx
-    }),
+    })
   )
 })
 
@@ -233,19 +233,19 @@ describe('optional fields', () => {
   const req = {
     optionalFields: {
       a: 1,
-      b: 1,
+      b: 1
     },
     category: {
       optionalFieldsNested: {
-        __scalar: 1,
-      },
+        __scalar: 1
+      }
     },
     argumentSyntax: {
-      optional: 1,
+      optional: 1
     },
     optionalObject: {
       x: 1,
-      optional: 1,
+      optional: 1
     }
   }
   const z: FieldsSelection<SRC, typeof req> = {} as any
@@ -266,7 +266,7 @@ describe('optional fields', () => {
       z.category.optionalFieldsNested.a
       // @ts-expect-error
       z.category?.optionalFieldsNested.a
-    }),
+    })
   )
   test(
     'optional objects are preserved',
@@ -276,7 +276,7 @@ describe('optional fields', () => {
       z.optionalObject?.x
       // type is T | null
       z.optionalObject = null
-    }),
+    })
   )
   test(
     'optional fields are preserved in __scalar',
@@ -290,7 +290,7 @@ describe('optional fields', () => {
       // @ts-expect-error
       z.category.optionalFieldsNested.a
       z.category?.optionalFieldsNested?.a?.toLocaleLowerCase
-    }),
+    })
   )
   test(
     'argument syntax',
@@ -298,7 +298,7 @@ describe('optional fields', () => {
       // @ts-expect-error optional
       z.argumentSyntax.optional.toLocaleLowerCase
       z.argumentSyntax?.optional?.toLocaleLowerCase
-    }),
+    })
   )
 })
 
@@ -307,27 +307,27 @@ describe('unions', () => {
     union: {
       onX: {
         a: 1,
-        __scalar: 1,
-      },
+        __scalar: 1
+      }
     },
     nesting: {
       nestedUnion: {
         onX: {
-          a: 1,
+          a: 1
         },
         onY: {
-          b: 1,
-        },
-      },
+          b: 1
+        }
+      }
     },
     argumentSyntax: {
       union: {
         a: 1,
         onX: {
-          b: 1,
-        },
-      },
-    },
+          b: 1
+        }
+      }
+    }
   }
   const z: FieldsSelection<SRC, typeof req> = {} as any
   test(
@@ -336,7 +336,7 @@ describe('unions', () => {
       z.union?.a.toLocaleLowerCase
       z.union?.a.toLocaleLowerCase
       z.nesting?.nestedUnion?.a.toLocaleLowerCase
-    }),
+    })
   )
   test(
     'does not have __isUnion',
@@ -345,7 +345,7 @@ describe('unions', () => {
       z.union.__isUnion
       // @ts-expect-error
       z.nesting.nestedUnion.__isUnion
-    }),
+    })
   )
   test(
     'argument syntax',
@@ -353,7 +353,7 @@ describe('unions', () => {
       z.argumentSyntax?.union?.a.charAt
       // @ts-expect-error
       z.argumentSyntax.a
-    }),
+    })
   )
 })
 
@@ -363,8 +363,8 @@ describe('hide fields in request', () => {
     category: {
       a: 1,
       b: SKIP,
-      c: false as const,
-    },
+      c: false as const
+    }
   }
   const z: FieldsSelection<SRC, typeof req> = {} as any
   // test(
@@ -384,23 +384,23 @@ describe('arrays', () => {
     list: {
       a: 1,
       x: 1,
-      optional: 1,
+      optional: 1
     },
     nested: {
       __args: { x: 1 },
       __scalar: 1,
       list: {
         edges: {
-          x: 1,
-        },
-      },
+          x: 1
+        }
+      }
     },
     argumentSyntax: {
       list: {
         x: 1,
-        optional: 1,
-      },
-    },
+        optional: 1
+      }
+    }
   }
   const z: FieldsSelection<SRC, typeof req> = {} as any
   test(
@@ -408,13 +408,13 @@ describe('arrays', () => {
     dontExecute(() => {
       z.list?.[0].a?.charCodeAt
       z.list?.[0].x?.toFixed
-    }),
+    })
   )
   test(
     'nested',
     dontExecute(() => {
       z.nested?.list?.[0]?.edges?.[0].x?.toFixed
-    }),
+    })
   )
   test(
     'maintain optionals',
@@ -422,7 +422,7 @@ describe('arrays', () => {
       // @ts-expect-error optional
       z.list[0].optional.bold
       z.list?.[0].optional?.bold
-    }),
+    })
   )
   test(
     'args syntax',
@@ -431,13 +431,13 @@ describe('arrays', () => {
       z.argumentSyntax?.list?.[0].optional?.charAt
       // @ts-expect-error optional
       z.argumentSyntax.list[0].optional.charAt
-    }),
+    })
   )
 })
 
 describe('literals unions', () => {
   const req = {
-    literalsUnion: 1,
+    literalsUnion: 1
   }
   const z: FieldsSelection<SRC, typeof req> = {} as any
   test(
@@ -448,7 +448,7 @@ describe('literals unions', () => {
       z.literalsUnion === 'b'
       // @ts-expect-error
       z.literalsUnion === 'x'
-    }),
+    })
   )
 })
 
@@ -456,8 +456,8 @@ describe('literals unions', () => {
   const req = {
     nullableField: {
       x: 1,
-      optional: 1,
-    },
+      optional: 1
+    }
   }
   const z: FieldsSelection<SRC, typeof req> = {} as any
   test(
@@ -467,7 +467,7 @@ describe('literals unions', () => {
       z.nullableField?.optional?.big
       // @ts-expect-error optional
       z.nullableField.optional.big
-    }),
+    })
   )
 })
 
@@ -506,7 +506,7 @@ test(
     x?.edges?.[0]?.node?.y?.toLocaleLowerCase
     x?.edges?.[0]?.nodes?.[0].x?.toLocaleLowerCase
     x?.edges?.[0]?.nodes?.[0].y?.toLocaleLowerCase
-  }),
+  })
 )
 
 ///////////////////////////////////// unions

--- a/cli/src/typeSelection.test.ts
+++ b/cli/src/typeSelection.test.ts
@@ -104,16 +104,16 @@ describe('pick', () => {
             a: 1,
             b: 1,
             nested1: {
-                a: 1
-            }
+                a: 1,
+            },
         },
         argumentSyntax: {
             __args: { x: 3 },
             a: 1,
             nesting: {
-                __scalar: 1
-            }
-        }
+                __scalar: 1,
+            },
+        },
     }
     const z: FieldsSelection<SRC, NoExtraProperties<typeof req>> = {} as any
     test(
@@ -125,7 +125,7 @@ describe('pick', () => {
             // @ts-expect-error
             z.category.c
             z.category?.nested1?.a
-        })
+        }),
     )
     test(
         'response type does not have additional properties',
@@ -141,13 +141,13 @@ describe('pick', () => {
             z.category.nested1.c
             // @ts-expect-error
             z.category.nested2
-        })
+        }),
     )
     test(
         'argument syntax',
         dontExecute(() => {
             z.argumentSyntax?.a?.toLocaleLowerCase
-        })
+        }),
     )
 })
 
@@ -157,16 +157,16 @@ describe('__scalar', () => {
         category: {
             __scalar: 1,
             nested1: {
-                a: 1
-            }
+                a: 1,
+            },
         },
         argumentSyntax: {
             __args: { a: 7 },
-            __scalar: 1
+            __scalar: 1,
         },
         argumentScalar: {
-            __args: { x: 9 }
-        }
+            __args: { x: 9 },
+        },
     }
     const z: FieldsSelection<SRC, typeof req> = {} as any
     test(
@@ -179,7 +179,7 @@ describe('__scalar', () => {
             z.category?.nested1.a
             z.category?.a.getDate
             z.category?.b.getDate
-        })
+        }),
     )
     test(
         'response type does not have additional properties',
@@ -193,21 +193,21 @@ describe('__scalar', () => {
             z.category.nested1.c
             // @ts-expect-error
             z.category.nested2
-        })
+        }),
     )
     test(
         '__scalar is not present',
         dontExecute(() => {
             // @ts-expect-error
             z.category.__scalar
-        })
+        }),
     )
     test(
         '__name is not present',
         dontExecute(() => {
             // @ts-expect-error __name
             z.__name
-        })
+        }),
     )
     test(
         'argument syntax',
@@ -216,7 +216,7 @@ describe('__scalar', () => {
             z.argumentSyntax?.optional?.big
             // @ts-expect-error
             z.argumentSyntax.nesting.x
-        })
+        }),
     )
     test(
         'argument syntax on scalar',
@@ -225,7 +225,7 @@ describe('__scalar', () => {
             z.argumentScalar?.charAt
             // @ts-expect-error
             z.argumentScalar.xx
-        })
+        }),
     )
 })
 
@@ -233,20 +233,20 @@ describe('optional fields', () => {
     const req = {
         optionalFields: {
             a: 1,
-            b: 1
+            b: 1,
         },
         category: {
             optionalFieldsNested: {
-                __scalar: 1
-            }
+                __scalar: 1,
+            },
         },
         argumentSyntax: {
-            optional: 1
+            optional: 1,
         },
         optionalObject: {
             x: 1,
-            optional: 1
-        }
+            optional: 1,
+        },
     }
     const z: FieldsSelection<SRC, typeof req> = {} as any
     test(
@@ -266,7 +266,7 @@ describe('optional fields', () => {
             z.category.optionalFieldsNested.a
             // @ts-expect-error
             z.category?.optionalFieldsNested.a
-        })
+        }),
     )
     test(
         'optional objects are preserved',
@@ -276,7 +276,7 @@ describe('optional fields', () => {
             z.optionalObject?.x
             // type is T | null
             z.optionalObject = null
-        })
+        }),
     )
     test(
         'optional fields are preserved in __scalar',
@@ -290,7 +290,7 @@ describe('optional fields', () => {
             // @ts-expect-error
             z.category.optionalFieldsNested.a
             z.category?.optionalFieldsNested?.a?.toLocaleLowerCase
-        })
+        }),
     )
     test(
         'argument syntax',
@@ -298,7 +298,7 @@ describe('optional fields', () => {
             // @ts-expect-error optional
             z.argumentSyntax.optional.toLocaleLowerCase
             z.argumentSyntax?.optional?.toLocaleLowerCase
-        })
+        }),
     )
 })
 
@@ -307,27 +307,27 @@ describe('unions', () => {
         union: {
             onX: {
                 a: 1,
-                __scalar: 1
-            }
+                __scalar: 1,
+            },
         },
         nesting: {
             nestedUnion: {
                 onX: {
-                    a: 1
+                    a: 1,
                 },
                 onY: {
-                    b: 1
-                }
-            }
+                    b: 1,
+                },
+            },
         },
         argumentSyntax: {
             union: {
                 a: 1,
                 onX: {
-                    b: 1
-                }
-            }
-        }
+                    b: 1,
+                },
+            },
+        },
     }
     const z: FieldsSelection<SRC, typeof req> = {} as any
     test(
@@ -336,7 +336,7 @@ describe('unions', () => {
             z.union?.a.toLocaleLowerCase
             z.union?.a.toLocaleLowerCase
             z.nesting?.nestedUnion?.a.toLocaleLowerCase
-        })
+        }),
     )
     test(
         'does not have __isUnion',
@@ -345,7 +345,7 @@ describe('unions', () => {
             z.union.__isUnion
             // @ts-expect-error
             z.nesting.nestedUnion.__isUnion
-        })
+        }),
     )
     test(
         'argument syntax',
@@ -353,7 +353,7 @@ describe('unions', () => {
             z.argumentSyntax?.union?.a.charAt
             // @ts-expect-error
             z.argumentSyntax.a
-        })
+        }),
     )
 })
 
@@ -363,8 +363,8 @@ describe('hide fields in request', () => {
         category: {
             a: 1,
             b: SKIP,
-            c: false as const
-        }
+            c: false as const,
+        },
     }
     const z: FieldsSelection<SRC, typeof req> = {} as any
     // test(
@@ -384,23 +384,23 @@ describe('arrays', () => {
         list: {
             a: 1,
             x: 1,
-            optional: 1
+            optional: 1,
         },
         nested: {
             __args: { x: 1 },
             __scalar: 1,
             list: {
                 edges: {
-                    x: 1
-                }
-            }
+                    x: 1,
+                },
+            },
         },
         argumentSyntax: {
             list: {
                 x: 1,
-                optional: 1
-            }
-        }
+                optional: 1,
+            },
+        },
     }
     const z: FieldsSelection<SRC, typeof req> = {} as any
     test(
@@ -408,13 +408,13 @@ describe('arrays', () => {
         dontExecute(() => {
             z.list?.[0].a?.charCodeAt
             z.list?.[0].x?.toFixed
-        })
+        }),
     )
     test(
         'nested',
         dontExecute(() => {
             z.nested?.list?.[0]?.edges?.[0].x?.toFixed
-        })
+        }),
     )
     test(
         'maintain optionals',
@@ -422,7 +422,7 @@ describe('arrays', () => {
             // @ts-expect-error optional
             z.list[0].optional.bold
             z.list?.[0].optional?.bold
-        })
+        }),
     )
     test(
         'args syntax',
@@ -431,13 +431,13 @@ describe('arrays', () => {
             z.argumentSyntax?.list?.[0].optional?.charAt
             // @ts-expect-error optional
             z.argumentSyntax.list[0].optional.charAt
-        })
+        }),
     )
 })
 
 describe('literals unions', () => {
     const req = {
-        literalsUnion: 1
+        literalsUnion: 1,
     }
     const z: FieldsSelection<SRC, typeof req> = {} as any
     test(
@@ -448,7 +448,7 @@ describe('literals unions', () => {
             z.literalsUnion === 'b'
             // @ts-expect-error
             z.literalsUnion === 'x'
-        })
+        }),
     )
 })
 
@@ -456,8 +456,8 @@ describe('literals unions', () => {
     const req = {
         nullableField: {
             x: 1,
-            optional: 1
-        }
+            optional: 1,
+        },
     }
     const z: FieldsSelection<SRC, typeof req> = {} as any
     test(
@@ -467,7 +467,7 @@ describe('literals unions', () => {
             z.nullableField?.optional?.big
             // @ts-expect-error optional
             z.nullableField.optional.big
-        })
+        }),
     )
 })
 
@@ -506,7 +506,7 @@ test(
         x?.edges?.[0]?.node?.y?.toLocaleLowerCase
         x?.edges?.[0]?.nodes?.[0].x?.toLocaleLowerCase
         x?.edges?.[0]?.nodes?.[0].y?.toLocaleLowerCase
-    })
+    }),
 )
 
 ///////////////////////////////////// unions

--- a/cli/src/typeSelection.test.ts
+++ b/cli/src/typeSelection.test.ts
@@ -16,497 +16,497 @@ import { FieldsSelection } from './runtime/typeSelection'
 */
 
 type SRC = {
-  literalsUnion: 'a' | 'b'
-  nullableField: null | { x: boolean; optional?: string }
-  list: {
-    x: number
-    a: string
-    optional?: string
-  }[]
-  nested?: {
-    list?: {
-      edges?: {
-        x?: number
-      }[]
+    literalsUnion: 'a' | 'b'
+    nullableField: null | { x: boolean; optional?: string }
+    list: {
+        x: number
+        a: string
+        optional?: string
     }[]
-  }
-  category: {
-    a: Date
-    b: Date
-    c: Date
-    nested1: {
-      a: string
-      b: string
-      c: string
+    nested?: {
+        list?: {
+            edges?: {
+                x?: number
+            }[]
+        }[]
     }
-    nested2: {
-      a: string
-      b: string
+    category: {
+        a: Date
+        b: Date
+        c: Date
+        nested1: {
+            a: string
+            b: string
+            c: string
+        }
+        nested2: {
+            a: string
+            b: string
+        }
+        optionalFieldsNested?: {
+            a?: string
+            b?: number
+        }
     }
-    optionalFieldsNested?: {
-      a?: string
-      b?: number
+    optionalFields: {
+        a?: string | null
+        b?: number | null
     }
-  }
-  optionalFields: {
-    a?: string | null
-    b?: number | null
-  }
-  optionalObject: {
-    x: string
-    optional: string | null
-  } | null
-  order: {
-    customer: {
-      address: {
-        city: 1
-        a: 1
-        b: 1
-      }
-    }
-  }
-  union:
-    | { a: string; __isUnion?: true }
-    | { a: string; b: string; __isUnion?: true }
-  nesting: {
-    nestedUnion:
-      | { a: string; __isUnion?: true }
-      | { a: string; b: string; __isUnion?: true }
-  }
-  xxx: {
-    xxx: boolean
-  }
-  yyy: {
-    yyy: boolean
-  }
-  argumentSyntax: {
-    a: string
-    optional?: string
-    nesting: {
-      x: number
-      y: number
+    optionalObject: {
+        x: string
+        optional: string | null
+    } | null
+    order: {
+        customer: {
+            address: {
+                city: 1
+                a: 1
+                b: 1
+            }
+        }
     }
     union:
-      | { a: string; __isUnion?: true }
-      | { a: string; b: string; __isUnion?: true }
-    list: {
-      x: number
-      a: string
-      optional?: string
-    }[]
-  }
-  argumentScalar?: string
+        | { a: string; __isUnion?: true }
+        | { a: string; b: string; __isUnion?: true }
+    nesting: {
+        nestedUnion:
+            | { a: string; __isUnion?: true }
+            | { a: string; b: string; __isUnion?: true }
+    }
+    xxx: {
+        xxx: boolean
+    }
+    yyy: {
+        yyy: boolean
+    }
+    argumentSyntax: {
+        a: string
+        optional?: string
+        nesting: {
+            x: number
+            y: number
+        }
+        union:
+            | { a: string; __isUnion?: true }
+            | { a: string; b: string; __isUnion?: true }
+        list: {
+            x: number
+            a: string
+            optional?: string
+        }[]
+    }
+    argumentScalar?: string
 }
 
 describe('pick', () => {
-  const req = {
-    category: {
-      a: 1,
-      b: 1,
-      nested1: {
-        a: 1
-      }
-    },
-    argumentSyntax: {
-      __args: { x: 3 },
-      a: 1,
-      nesting: {
-        __scalar: 1
-      }
+    const req = {
+        category: {
+            a: 1,
+            b: 1,
+            nested1: {
+                a: 1
+            }
+        },
+        argumentSyntax: {
+            __args: { x: 3 },
+            a: 1,
+            nesting: {
+                __scalar: 1
+            }
+        }
     }
-  }
-  const z: FieldsSelection<SRC, NoExtraProperties<typeof req>> = {} as any
-  test(
-    'response type picks from request type',
-    dontExecute(() => {
-      z.category
-      z.category?.a
-      z.category?.b
-      // @ts-expect-error
-      z.category.c
-      z.category?.nested1?.a
-    })
-  )
-  test(
-    'response type does not have additional properties',
-    dontExecute(() => {
-      // TODO i can access keys with value type equal never
-      // @ts-expect-error
-      z.order
-      // @ts-expect-error
-      z.category.nested1.b
-      // @ts-expect-error
-      z.category.nested1.b
-      // @ts-expect-error
-      z.category.nested1.c
-      // @ts-expect-error
-      z.category.nested2
-    })
-  )
-  test(
-    'argument syntax',
-    dontExecute(() => {
-      z.argumentSyntax?.a?.toLocaleLowerCase
-    })
-  )
+    const z: FieldsSelection<SRC, NoExtraProperties<typeof req>> = {} as any
+    test(
+        'response type picks from request type',
+        dontExecute(() => {
+            z.category
+            z.category?.a
+            z.category?.b
+            // @ts-expect-error
+            z.category.c
+            z.category?.nested1?.a
+        })
+    )
+    test(
+        'response type does not have additional properties',
+        dontExecute(() => {
+            // TODO i can access keys with value type equal never
+            // @ts-expect-error
+            z.order
+            // @ts-expect-error
+            z.category.nested1.b
+            // @ts-expect-error
+            z.category.nested1.b
+            // @ts-expect-error
+            z.category.nested1.c
+            // @ts-expect-error
+            z.category.nested2
+        })
+    )
+    test(
+        'argument syntax',
+        dontExecute(() => {
+            z.argumentSyntax?.a?.toLocaleLowerCase
+        })
+    )
 })
 
 describe('__scalar', () => {
-  const req = {
-    __name: 'name',
-    category: {
-      __scalar: 1,
-      nested1: {
-        a: 1
-      }
-    },
-    argumentSyntax: {
-      __args: { a: 7 },
-      __scalar: 1
-    },
-    argumentScalar: {
-      __args: { x: 9 }
+    const req = {
+        __name: 'name',
+        category: {
+            __scalar: 1,
+            nested1: {
+                a: 1
+            }
+        },
+        argumentSyntax: {
+            __args: { a: 7 },
+            __scalar: 1
+        },
+        argumentScalar: {
+            __args: { x: 9 }
+        }
     }
-  }
-  const z: FieldsSelection<SRC, typeof req> = {} as any
-  test(
-    'response type picks from request type',
-    dontExecute(() => {
-      z.category
-      z.category?.a
-      z.category?.b
-      z.category?.c
-      z.category?.nested1.a
-      z.category?.a.getDate
-      z.category?.b.getDate
-    })
-  )
-  test(
-    'response type does not have additional properties',
-    dontExecute(() => {
-      // TODO i can access keys with value type equal never
-      // @ts-expect-error
-      z.order
-      // @ts-expect-error
-      z.category.nested1.b
-      // @ts-expect-error
-      z.category.nested1.c
-      // @ts-expect-error
-      z.category.nested2
-    })
-  )
-  test(
-    '__scalar is not present',
-    dontExecute(() => {
-      // @ts-expect-error
-      z.category.__scalar
-    })
-  )
-  test(
-    '__name is not present',
-    dontExecute(() => {
-      // @ts-expect-error __name
-      z.__name
-    })
-  )
-  test(
-    'argument syntax',
-    dontExecute(() => {
-      z.argumentSyntax?.a.toLocaleLowerCase
-      z.argumentSyntax?.optional?.big
-      // @ts-expect-error
-      z.argumentSyntax.nesting.x
-    })
-  )
-  test(
-    'argument syntax on scalar',
-    dontExecute(() => {
-      z.argumentScalar
-      z.argumentScalar?.charAt
-      // @ts-expect-error
-      z.argumentScalar.xx
-    })
-  )
+    const z: FieldsSelection<SRC, typeof req> = {} as any
+    test(
+        'response type picks from request type',
+        dontExecute(() => {
+            z.category
+            z.category?.a
+            z.category?.b
+            z.category?.c
+            z.category?.nested1.a
+            z.category?.a.getDate
+            z.category?.b.getDate
+        })
+    )
+    test(
+        'response type does not have additional properties',
+        dontExecute(() => {
+            // TODO i can access keys with value type equal never
+            // @ts-expect-error
+            z.order
+            // @ts-expect-error
+            z.category.nested1.b
+            // @ts-expect-error
+            z.category.nested1.c
+            // @ts-expect-error
+            z.category.nested2
+        })
+    )
+    test(
+        '__scalar is not present',
+        dontExecute(() => {
+            // @ts-expect-error
+            z.category.__scalar
+        })
+    )
+    test(
+        '__name is not present',
+        dontExecute(() => {
+            // @ts-expect-error __name
+            z.__name
+        })
+    )
+    test(
+        'argument syntax',
+        dontExecute(() => {
+            z.argumentSyntax?.a.toLocaleLowerCase
+            z.argumentSyntax?.optional?.big
+            // @ts-expect-error
+            z.argumentSyntax.nesting.x
+        })
+    )
+    test(
+        'argument syntax on scalar',
+        dontExecute(() => {
+            z.argumentScalar
+            z.argumentScalar?.charAt
+            // @ts-expect-error
+            z.argumentScalar.xx
+        })
+    )
 })
 
 describe('optional fields', () => {
-  const req = {
-    optionalFields: {
-      a: 1,
-      b: 1
-    },
-    category: {
-      optionalFieldsNested: {
-        __scalar: 1
-      }
-    },
-    argumentSyntax: {
-      optional: 1
-    },
-    optionalObject: {
-      x: 1,
-      optional: 1
+    const req = {
+        optionalFields: {
+            a: 1,
+            b: 1
+        },
+        category: {
+            optionalFieldsNested: {
+                __scalar: 1
+            }
+        },
+        argumentSyntax: {
+            optional: 1
+        },
+        optionalObject: {
+            x: 1,
+            optional: 1
+        }
     }
-  }
-  const z: FieldsSelection<SRC, typeof req> = {} as any
-  test(
-    'optional fields are preserved',
-    dontExecute(() => {
-      // @ts-expect-error
-      z.optionalFields.a.toLocaleLowerCase
-      z.optionalFields?.a?.toLocaleLowerCase
+    const z: FieldsSelection<SRC, typeof req> = {} as any
+    test(
+        'optional fields are preserved',
+        dontExecute(() => {
+            // @ts-expect-error
+            z.optionalFields.a.toLocaleLowerCase
+            z.optionalFields?.a?.toLocaleLowerCase
 
-      // can use null
-      z.optionalFields!.a = null
+            // can use null
+            z.optionalFields!.a = null
 
-      // @ts-expect-error
-      z.optionalFields.b.toLocaleLowerCase
-      z.optionalFields?.b?.toFixed
-      // @ts-expect-error
-      z.category.optionalFieldsNested.a
-      // @ts-expect-error
-      z.category?.optionalFieldsNested.a
-    })
-  )
-  test(
-    'optional objects are preserved',
-    dontExecute(() => {
-      // @ts-expect-error
-      z.optionalObject.x
-      z.optionalObject?.x
-      // type is T | null
-      z.optionalObject = null
-    })
-  )
-  test(
-    'optional fields are preserved in __scalar',
-    dontExecute(() => {
-      // @ts-expect-error
-      z.optionalFields.a.toLocaleLowerCase
-      z.optionalFields?.a?.toLocaleLowerCase
-      // @ts-expect-error
-      z.optionalFields.b.toLocaleLowerCase
-      z.optionalFields?.b?.toFixed
-      // @ts-expect-error
-      z.category.optionalFieldsNested.a
-      z.category?.optionalFieldsNested?.a?.toLocaleLowerCase
-    })
-  )
-  test(
-    'argument syntax',
-    dontExecute(() => {
-      // @ts-expect-error optional
-      z.argumentSyntax.optional.toLocaleLowerCase
-      z.argumentSyntax?.optional?.toLocaleLowerCase
-    })
-  )
+            // @ts-expect-error
+            z.optionalFields.b.toLocaleLowerCase
+            z.optionalFields?.b?.toFixed
+            // @ts-expect-error
+            z.category.optionalFieldsNested.a
+            // @ts-expect-error
+            z.category?.optionalFieldsNested.a
+        })
+    )
+    test(
+        'optional objects are preserved',
+        dontExecute(() => {
+            // @ts-expect-error
+            z.optionalObject.x
+            z.optionalObject?.x
+            // type is T | null
+            z.optionalObject = null
+        })
+    )
+    test(
+        'optional fields are preserved in __scalar',
+        dontExecute(() => {
+            // @ts-expect-error
+            z.optionalFields.a.toLocaleLowerCase
+            z.optionalFields?.a?.toLocaleLowerCase
+            // @ts-expect-error
+            z.optionalFields.b.toLocaleLowerCase
+            z.optionalFields?.b?.toFixed
+            // @ts-expect-error
+            z.category.optionalFieldsNested.a
+            z.category?.optionalFieldsNested?.a?.toLocaleLowerCase
+        })
+    )
+    test(
+        'argument syntax',
+        dontExecute(() => {
+            // @ts-expect-error optional
+            z.argumentSyntax.optional.toLocaleLowerCase
+            z.argumentSyntax?.optional?.toLocaleLowerCase
+        })
+    )
 })
 
 describe('unions', () => {
-  const req = {
-    union: {
-      onX: {
-        a: 1,
-        __scalar: 1
-      }
-    },
-    nesting: {
-      nestedUnion: {
-        onX: {
-          a: 1
+    const req = {
+        union: {
+            onX: {
+                a: 1,
+                __scalar: 1
+            }
         },
-        onY: {
-          b: 1
+        nesting: {
+            nestedUnion: {
+                onX: {
+                    a: 1
+                },
+                onY: {
+                    b: 1
+                }
+            }
+        },
+        argumentSyntax: {
+            union: {
+                a: 1,
+                onX: {
+                    b: 1
+                }
+            }
         }
-      }
-    },
-    argumentSyntax: {
-      union: {
-        a: 1,
-        onX: {
-          b: 1
-        }
-      }
     }
-  }
-  const z: FieldsSelection<SRC, typeof req> = {} as any
-  test(
-    'pick union fields',
-    dontExecute(() => {
-      z.union?.a.toLocaleLowerCase
-      z.union?.a.toLocaleLowerCase
-      z.nesting?.nestedUnion?.a.toLocaleLowerCase
-    })
-  )
-  test(
-    'does not have __isUnion',
-    dontExecute(() => {
-      // @ts-expect-error
-      z.union.__isUnion
-      // @ts-expect-error
-      z.nesting.nestedUnion.__isUnion
-    })
-  )
-  test(
-    'argument syntax',
-    dontExecute(() => {
-      z.argumentSyntax?.union?.a.charAt
-      // @ts-expect-error
-      z.argumentSyntax.a
-    })
-  )
+    const z: FieldsSelection<SRC, typeof req> = {} as any
+    test(
+        'pick union fields',
+        dontExecute(() => {
+            z.union?.a.toLocaleLowerCase
+            z.union?.a.toLocaleLowerCase
+            z.nesting?.nestedUnion?.a.toLocaleLowerCase
+        })
+    )
+    test(
+        'does not have __isUnion',
+        dontExecute(() => {
+            // @ts-expect-error
+            z.union.__isUnion
+            // @ts-expect-error
+            z.nesting.nestedUnion.__isUnion
+        })
+    )
+    test(
+        'argument syntax',
+        dontExecute(() => {
+            z.argumentSyntax?.union?.a.charAt
+            // @ts-expect-error
+            z.argumentSyntax.a
+        })
+    )
 })
 
 describe('hide fields in request', () => {
-  const SKIP: false = false
-  const req = {
-    category: {
-      a: 1,
-      b: SKIP,
-      c: false as const
+    const SKIP: false = false
+    const req = {
+        category: {
+            a: 1,
+            b: SKIP,
+            c: false as const
+        }
     }
-  }
-  const z: FieldsSelection<SRC, typeof req> = {} as any
-  // test(
-  //     'cannot access falsy fields',
-  //     dontExecute(() => {
-  //         z.category.a
-  //         // @ts-expect-error inaccessible
-  //         z.category.b
-  //         // @ts-expect-error inaccessible
-  //         z.category.c
-  //     }),
-  // )
+    const z: FieldsSelection<SRC, typeof req> = {} as any
+    // test(
+    //     'cannot access falsy fields',
+    //     dontExecute(() => {
+    //         z.category.a
+    //         // @ts-expect-error inaccessible
+    //         z.category.b
+    //         // @ts-expect-error inaccessible
+    //         z.category.c
+    //     }),
+    // )
 })
 
 describe('arrays', () => {
-  const req = {
-    list: {
-      a: 1,
-      x: 1,
-      optional: 1
-    },
-    nested: {
-      __args: { x: 1 },
-      __scalar: 1,
-      list: {
-        edges: {
-          x: 1
+    const req = {
+        list: {
+            a: 1,
+            x: 1,
+            optional: 1
+        },
+        nested: {
+            __args: { x: 1 },
+            __scalar: 1,
+            list: {
+                edges: {
+                    x: 1
+                }
+            }
+        },
+        argumentSyntax: {
+            list: {
+                x: 1,
+                optional: 1
+            }
         }
-      }
-    },
-    argumentSyntax: {
-      list: {
-        x: 1,
-        optional: 1
-      }
     }
-  }
-  const z: FieldsSelection<SRC, typeof req> = {} as any
-  test(
-    'list',
-    dontExecute(() => {
-      z.list?.[0].a?.charCodeAt
-      z.list?.[0].x?.toFixed
-    })
-  )
-  test(
-    'nested',
-    dontExecute(() => {
-      z.nested?.list?.[0]?.edges?.[0].x?.toFixed
-    })
-  )
-  test(
-    'maintain optionals',
-    dontExecute(() => {
-      // @ts-expect-error optional
-      z.list[0].optional.bold
-      z.list?.[0].optional?.bold
-    })
-  )
-  test(
-    'args syntax',
-    dontExecute(() => {
-      z.argumentSyntax?.list?.[0].x
-      z.argumentSyntax?.list?.[0].optional?.charAt
-      // @ts-expect-error optional
-      z.argumentSyntax.list[0].optional.charAt
-    })
-  )
+    const z: FieldsSelection<SRC, typeof req> = {} as any
+    test(
+        'list',
+        dontExecute(() => {
+            z.list?.[0].a?.charCodeAt
+            z.list?.[0].x?.toFixed
+        })
+    )
+    test(
+        'nested',
+        dontExecute(() => {
+            z.nested?.list?.[0]?.edges?.[0].x?.toFixed
+        })
+    )
+    test(
+        'maintain optionals',
+        dontExecute(() => {
+            // @ts-expect-error optional
+            z.list[0].optional.bold
+            z.list?.[0].optional?.bold
+        })
+    )
+    test(
+        'args syntax',
+        dontExecute(() => {
+            z.argumentSyntax?.list?.[0].x
+            z.argumentSyntax?.list?.[0].optional?.charAt
+            // @ts-expect-error optional
+            z.argumentSyntax.list[0].optional.charAt
+        })
+    )
 })
 
 describe('literals unions', () => {
-  const req = {
-    literalsUnion: 1
-  }
-  const z: FieldsSelection<SRC, typeof req> = {} as any
-  test(
-    'literals',
-    dontExecute(() => {
-      z.literalsUnion?.blink
-      z.literalsUnion === 'a'
-      z.literalsUnion === 'b'
-      // @ts-expect-error
-      z.literalsUnion === 'x'
-    })
-  )
+    const req = {
+        literalsUnion: 1
+    }
+    const z: FieldsSelection<SRC, typeof req> = {} as any
+    test(
+        'literals',
+        dontExecute(() => {
+            z.literalsUnion?.blink
+            z.literalsUnion === 'a'
+            z.literalsUnion === 'b'
+            // @ts-expect-error
+            z.literalsUnion === 'x'
+        })
+    )
 })
 
 describe('literals unions', () => {
-  const req = {
-    nullableField: {
-      x: 1,
-      optional: 1
+    const req = {
+        nullableField: {
+            x: 1,
+            optional: 1
+        }
     }
-  }
-  const z: FieldsSelection<SRC, typeof req> = {} as any
-  test(
-    'accessible',
-    dontExecute(() => {
-      z.nullableField?.x
-      z.nullableField?.optional?.big
-      // @ts-expect-error optional
-      z.nullableField.optional.big
-    })
-  )
+    const z: FieldsSelection<SRC, typeof req> = {} as any
+    test(
+        'accessible',
+        dontExecute(() => {
+            z.nullableField?.x
+            z.nullableField?.optional?.big
+            // @ts-expect-error optional
+            z.nullableField.optional.big
+        })
+    )
 })
 
 test(
-  'complex optional type with array',
-  dontExecute(() => {
-    interface ForkConnection {
-      edges?: (ForkEdge | undefined)[]
-      __typename?: 'ForkConnection'
-    }
-
-    interface ForkEdge {
-      cursor?: string
-      node?: { x: string; y: string }
-      nodes?: { x?: string; y?: string }[]
-      __typename?: 'ForkEdge'
-    }
-
-    // issue
-    type X = FieldsSelection<
-      ForkConnection | undefined,
-      {
-        edges?: {
-          node: {
-            x: 1
-          }
-          nodes: {
-            __scalar: 1
-          }
+    'complex optional type with array',
+    dontExecute(() => {
+        interface ForkConnection {
+            edges?: (ForkEdge | undefined)[]
+            __typename?: 'ForkConnection'
         }
-      }
-    >
-    const x: X = {} as any
-    x?.edges?.[0]?.node?.x?.toLocaleLowerCase
-    // @ts-expect-error not present
-    x?.edges?.[0]?.node?.y?.toLocaleLowerCase
-    x?.edges?.[0]?.nodes?.[0].x?.toLocaleLowerCase
-    x?.edges?.[0]?.nodes?.[0].y?.toLocaleLowerCase
-  })
+
+        interface ForkEdge {
+            cursor?: string
+            node?: { x: string; y: string }
+            nodes?: { x?: string; y?: string }[]
+            __typename?: 'ForkEdge'
+        }
+
+        // issue
+        type X = FieldsSelection<
+            ForkConnection | undefined,
+            {
+                edges?: {
+                    node: {
+                        x: 1
+                    }
+                    nodes: {
+                        __scalar: 1
+                    }
+                }
+            }
+        >
+        const x: X = {} as any
+        x?.edges?.[0]?.node?.x?.toLocaleLowerCase
+        // @ts-expect-error not present
+        x?.edges?.[0]?.node?.y?.toLocaleLowerCase
+        x?.edges?.[0]?.nodes?.[0].x?.toLocaleLowerCase
+        x?.edges?.[0]?.nodes?.[0].y?.toLocaleLowerCase
+    })
 )
 
 ///////////////////////////////////// unions
@@ -599,12 +599,12 @@ test(
 // }
 
 function dontExecute(f: any) {
-  return () => {}
+    return () => {}
 }
 
 type Impossible<K extends keyof any> = {
-  [P in K]: never
+    [P in K]: never
 }
 
 type NoExtraProperties<T, U extends T = T> = U &
-  Impossible<Exclude<keyof U, keyof T>>
+    Impossible<Exclude<keyof U, keyof T>>

--- a/cli/src/typeSelection.test.ts
+++ b/cli/src/typeSelection.test.ts
@@ -16,496 +16,497 @@ import { FieldsSelection } from './runtime/typeSelection'
 */
 
 type SRC = {
-    literalsUnion: 'a' | 'b'
-    nullableField: null | { x: boolean; optional?: string }
-    list: {
-        x: number
-        a: string
-        optional?: string
+  literalsUnion: 'a' | 'b'
+  nullableField: null | { x: boolean; optional?: string }
+  list: {
+    x: number
+    a: string
+    optional?: string
+  }[]
+  nested?: {
+    list?: {
+      edges?: {
+        x?: number
+      }[]
     }[]
-    nested?: {
-        list?: {
-            edges?: {
-                x?: number
-            }[]
-        }[]
+  }
+  category: {
+    a: Date
+    b: Date
+    c: Date
+    nested1: {
+      a: string
+      b: string
+      c: string
     }
-    category: {
-        a: Date
-        b: Date
-        c: Date
-        nested1: {
-            a: string
-            b: string
-            c: string
-        }
-        nested2: {
-            a: string
-            b: string
-        }
-        optionalFieldsNested?: {
-            a?: string
-            b?: number
-        }
+    nested2: {
+      a: string
+      b: string
     }
-    optionalFields: {
-        a?: string | null
-        b?: number | null
+    optionalFieldsNested?: {
+      a?: string
+      b?: number
     }
-    optionalObject: {
-        x: string
-        optional: string | null
-    } | null
-    order: {
-        customer: {
-            address: {
-                city: 1
-                a: 1
-                b: 1
-            }
-        }
+  }
+  optionalFields: {
+    a?: string | null
+    b?: number | null
+  }
+  optionalObject: {
+    x: string
+    optional: string | null
+  } | null
+  order: {
+    customer: {
+      address: {
+        city: 1
+        a: 1
+        b: 1
+      }
+    }
+  }
+  union:
+    | { a: string; __isUnion?: true }
+    | { a: string; b: string; __isUnion?: true }
+  nesting: {
+    nestedUnion:
+      | { a: string; __isUnion?: true }
+      | { a: string; b: string; __isUnion?: true }
+  }
+  xxx: {
+    xxx: boolean
+  }
+  yyy: {
+    yyy: boolean
+  }
+  argumentSyntax: {
+    a: string
+    optional?: string
+    nesting: {
+      x: number
+      y: number
     }
     union:
-        | { a: string; __isUnion?: true }
-        | { a: string; b: string; __isUnion?: true }
-    nesting: {
-        nestedUnion:
-            | { a: string; __isUnion?: true }
-            | { a: string; b: string; __isUnion?: true }
-    }
-    xxx: {
-        xxx: boolean
-    }
-    yyy: {
-        yyy: boolean
-    }
-    argumentSyntax: {
-        a: string
-        optional?: string
-        nesting: {
-            x: number
-            y: number
-        }
-        union:
-            | { a: string; __isUnion?: true }
-            | { a: string; b: string; __isUnion?: true }
-        list: {
-            x: number
-            a: string
-            optional?: string
-        }[]
-    }
-    argumentScalar?: string
+      | { a: string; __isUnion?: true }
+      | { a: string; b: string; __isUnion?: true }
+    list: {
+      x: number
+      a: string
+      optional?: string
+    }[]
+  }
+  argumentScalar?: string
 }
 
 describe('pick', () => {
-    const req = {
-        category: {
-            a: 1,
-            b: 1,
-            nested1: {
-                a: 1,
-            },
-        },
-        argumentSyntax: {
-            __args: { x: 3 },
-            a: 1,
-            nesting: {
-                __scalar: 1,
-            },
-        },
-    }
-    const z: FieldsSelection<SRC, NoExtraProperties<typeof req>> = {} as any
-    test(
-        'response type picks from request type',
-        dontExecute(() => {
-            z.category
-            z.category.a
-            z.category.b
-            // @ts-expect-error
-            z.category.c
-            z.category.nested1.a
-        }),
-    )
-    test(
-        'response type does not have additional properties',
-        dontExecute(() => {
-            // TODO i can access keys with value type equal never
-            // @ts-expect-error
-            z.order
-            // @ts-expect-error
-            z.category.nested1.b
-            // @ts-expect-error
-            z.category.nested1.b
-            // @ts-expect-error
-            z.category.nested1.c
-            // @ts-expect-error
-            z.category.nested2
-        }),
-    )
-    test(
-        'argument syntax',
-        dontExecute(() => {
-            z.argumentSyntax.a.toLocaleLowerCase
-        }),
-    )
+  const req = {
+    category: {
+      a: 1,
+      b: 1,
+      nested1: {
+        a: 1,
+      },
+    },
+    argumentSyntax: {
+      __args: { x: 3 },
+      a: 1,
+      nesting: {
+        __scalar: 1,
+      },
+    },
+  }
+  const z: FieldsSelection<SRC, NoExtraProperties<typeof req>> = {} as any
+  test(
+    'response type picks from request type',
+    dontExecute(() => {
+      z.category
+      z.category?.a
+      z.category?.b
+      // @ts-expect-error
+      z.category.c
+      z.category?.nested1?.a
+    }),
+  )
+  test(
+    'response type does not have additional properties',
+    dontExecute(() => {
+      // TODO i can access keys with value type equal never
+      // @ts-expect-error
+      z.order
+      // @ts-expect-error
+      z.category.nested1.b
+      // @ts-expect-error
+      z.category.nested1.b
+      // @ts-expect-error
+      z.category.nested1.c
+      // @ts-expect-error
+      z.category.nested2
+    }),
+  )
+  test(
+    'argument syntax',
+    dontExecute(() => {
+      z.argumentSyntax?.a?.toLocaleLowerCase
+    }),
+  )
 })
 
 describe('__scalar', () => {
-    const req = {
-        __name: 'name',
-        category: {
-            __scalar: 1,
-            nested1: {
-                a: 1,
-            },
-        },
-        argumentSyntax: {
-            __args: { a: 7 },
-            __scalar: 1,
-        },
-        argumentScalar: {
-            __args: { x: 9 },
-        },
-    }
-    const z: FieldsSelection<SRC, typeof req> = {} as any
-    test(
-        'response type picks from request type',
-        dontExecute(() => {
-            z.category
-            z.category.a
-            z.category.b
-            z.category.c
-            z.category.nested1.a
-            z.category.a.getDate
-            z.category.b.getDate
-        }),
-    )
-    test(
-        'response type does not have additional properties',
-        dontExecute(() => {
-            // TODO i can access keys with value type equal never
-            // @ts-expect-error
-            z.order
-            // @ts-expect-error
-            z.category.nested1.b
-            // @ts-expect-error
-            z.category.nested1.c
-            // @ts-expect-error
-            z.category.nested2
-        }),
-    )
-    test(
-        '__scalar is not present',
-        dontExecute(() => {
-            // @ts-expect-error
-            z.category.__scalar
-        }),
-    )
-    test(
-        '__name is not present',
-        dontExecute(() => {
-            // @ts-expect-error __name
-            z.__name
-        }),
-    )
-    test(
-        'argument syntax',
-        dontExecute(() => {
-            z.argumentSyntax.a.toLocaleLowerCase
-            z.argumentSyntax.optional?.big
-            // @ts-expect-error
-            z.argumentSyntax.nesting.x
-        }),
-    )
-    test(
-        'argument syntax on scalar',
-        dontExecute(() => {
-            z.argumentScalar
-            z.argumentScalar?.charAt
-            // @ts-expect-error
-            z.argumentScalar.xx
-        }),
-    )
+  const req = {
+    __name: 'name',
+    category: {
+      __scalar: 1,
+      nested1: {
+        a: 1,
+      },
+    },
+    argumentSyntax: {
+      __args: { a: 7 },
+      __scalar: 1,
+    },
+    argumentScalar: {
+      __args: { x: 9 },
+    },
+  }
+  const z: FieldsSelection<SRC, typeof req> = {} as any
+  test(
+    'response type picks from request type',
+    dontExecute(() => {
+      z.category
+      z.category?.a
+      z.category?.b
+      z.category?.c
+      z.category?.nested1.a
+      z.category?.a.getDate
+      z.category?.b.getDate
+    }),
+  )
+  test(
+    'response type does not have additional properties',
+    dontExecute(() => {
+      // TODO i can access keys with value type equal never
+      // @ts-expect-error
+      z.order
+      // @ts-expect-error
+      z.category.nested1.b
+      // @ts-expect-error
+      z.category.nested1.c
+      // @ts-expect-error
+      z.category.nested2
+    }),
+  )
+  test(
+    '__scalar is not present',
+    dontExecute(() => {
+      // @ts-expect-error
+      z.category.__scalar
+    }),
+  )
+  test(
+    '__name is not present',
+    dontExecute(() => {
+      // @ts-expect-error __name
+      z.__name
+    }),
+  )
+  test(
+    'argument syntax',
+    dontExecute(() => {
+      z.argumentSyntax?.a.toLocaleLowerCase
+      z.argumentSyntax?.optional?.big
+      // @ts-expect-error
+      z.argumentSyntax.nesting.x
+    }),
+  )
+  test(
+    'argument syntax on scalar',
+    dontExecute(() => {
+      z.argumentScalar
+      z.argumentScalar?.charAt
+      // @ts-expect-error
+      z.argumentScalar.xx
+    }),
+  )
 })
 
 describe('optional fields', () => {
-    const req = {
-        optionalFields: {
-            a: 1,
-            b: 1,
-        },
-        category: {
-            optionalFieldsNested: {
-                __scalar: 1,
-            },
-        },
-        argumentSyntax: {
-            optional: 1,
-        },
-        optionalObject: {
-            x: 1,
-            optional: 1,
-        }
+  const req = {
+    optionalFields: {
+      a: 1,
+      b: 1,
+    },
+    category: {
+      optionalFieldsNested: {
+        __scalar: 1,
+      },
+    },
+    argumentSyntax: {
+      optional: 1,
+    },
+    optionalObject: {
+      x: 1,
+      optional: 1,
     }
-    const z: FieldsSelection<SRC, typeof req> = {} as any
-    test(
-        'optional fields are preserved',
-        dontExecute(() => {
-            // @ts-expect-error
-            z.optionalFields.a.toLocaleLowerCase
-            z.optionalFields.a?.toLocaleLowerCase
+  }
+  const z: FieldsSelection<SRC, typeof req> = {} as any
+  test(
+    'optional fields are preserved',
+    dontExecute(() => {
+      // @ts-expect-error
+      z.optionalFields.a.toLocaleLowerCase
+      z.optionalFields?.a?.toLocaleLowerCase
 
-            // can use null
-            z.optionalFields.a = null
-            // @ts-expect-error
-            z.optionalFields.b.toLocaleLowerCase
-            z.optionalFields.b?.toFixed
-            // @ts-expect-error
-            z.category.optionalFieldsNested.a
-            // @ts-expect-error
-            z.category?.optionalFieldsNested.a
-        }),
-    )
-    test(
-        'optional objects are preserved',
-        dontExecute(() => {
-            // @ts-expect-error
-            z.optionalObject.x
-            z.optionalObject?.x
-            // type is T | null
-            z.optionalObject = null
-        }),
-    )
-    test(
-        'optional fields are preserved in __scalar',
-        dontExecute(() => {
-            // @ts-expect-error
-            z.optionalFields.a.toLocaleLowerCase
-            z.optionalFields.a?.toLocaleLowerCase
-            // @ts-expect-error
-            z.optionalFields.b.toLocaleLowerCase
-            z.optionalFields.b?.toFixed
-            // @ts-expect-error
-            z.category.optionalFieldsNested.a
-            z.category.optionalFieldsNested?.a?.toLocaleLowerCase
-        }),
-    )
-    test(
-        'argument syntax',
-        dontExecute(() => {
-            // @ts-expect-error optional
-            z.argumentSyntax.optional.toLocaleLowerCase
-            z.argumentSyntax.optional?.toLocaleLowerCase
-        }),
-    )
+      // can use null
+      z.optionalFields!.a = null
+
+      // @ts-expect-error
+      z.optionalFields.b.toLocaleLowerCase
+      z.optionalFields?.b?.toFixed
+      // @ts-expect-error
+      z.category.optionalFieldsNested.a
+      // @ts-expect-error
+      z.category?.optionalFieldsNested.a
+    }),
+  )
+  test(
+    'optional objects are preserved',
+    dontExecute(() => {
+      // @ts-expect-error
+      z.optionalObject.x
+      z.optionalObject?.x
+      // type is T | null
+      z.optionalObject = null
+    }),
+  )
+  test(
+    'optional fields are preserved in __scalar',
+    dontExecute(() => {
+      // @ts-expect-error
+      z.optionalFields.a.toLocaleLowerCase
+      z.optionalFields?.a?.toLocaleLowerCase
+      // @ts-expect-error
+      z.optionalFields.b.toLocaleLowerCase
+      z.optionalFields?.b?.toFixed
+      // @ts-expect-error
+      z.category.optionalFieldsNested.a
+      z.category?.optionalFieldsNested?.a?.toLocaleLowerCase
+    }),
+  )
+  test(
+    'argument syntax',
+    dontExecute(() => {
+      // @ts-expect-error optional
+      z.argumentSyntax.optional.toLocaleLowerCase
+      z.argumentSyntax?.optional?.toLocaleLowerCase
+    }),
+  )
 })
 
 describe('unions', () => {
-    const req = {
-        union: {
-            onX: {
-                a: 1,
-                __scalar: 1,
-            },
+  const req = {
+    union: {
+      onX: {
+        a: 1,
+        __scalar: 1,
+      },
+    },
+    nesting: {
+      nestedUnion: {
+        onX: {
+          a: 1,
         },
-        nesting: {
-            nestedUnion: {
-                onX: {
-                    a: 1,
-                },
-                onY: {
-                    b: 1,
-                },
-            },
+        onY: {
+          b: 1,
         },
-        argumentSyntax: {
-            union: {
-                a: 1,
-                onX: {
-                    b: 1,
-                },
-            },
+      },
+    },
+    argumentSyntax: {
+      union: {
+        a: 1,
+        onX: {
+          b: 1,
         },
-    }
-    const z: FieldsSelection<SRC, typeof req> = {} as any
-    test(
-        'pick union fields',
-        dontExecute(() => {
-            z.union.a.toLocaleLowerCase
-            z.union.a.toLocaleLowerCase
-            z.nesting.nestedUnion.a.toLocaleLowerCase
-        }),
-    )
-    test(
-        'does not have __isUnion',
-        dontExecute(() => {
-            // @ts-expect-error
-            z.union.__isUnion
-            // @ts-expect-error
-            z.nesting.nestedUnion.__isUnion
-        }),
-    )
-    test(
-        'argument syntax',
-        dontExecute(() => {
-            z.argumentSyntax.union.a.charAt
-            // @ts-expect-error
-            z.argumentSyntax.a
-        }),
-    )
+      },
+    },
+  }
+  const z: FieldsSelection<SRC, typeof req> = {} as any
+  test(
+    'pick union fields',
+    dontExecute(() => {
+      z.union?.a.toLocaleLowerCase
+      z.union?.a.toLocaleLowerCase
+      z.nesting?.nestedUnion?.a.toLocaleLowerCase
+    }),
+  )
+  test(
+    'does not have __isUnion',
+    dontExecute(() => {
+      // @ts-expect-error
+      z.union.__isUnion
+      // @ts-expect-error
+      z.nesting.nestedUnion.__isUnion
+    }),
+  )
+  test(
+    'argument syntax',
+    dontExecute(() => {
+      z.argumentSyntax?.union?.a.charAt
+      // @ts-expect-error
+      z.argumentSyntax.a
+    }),
+  )
 })
 
 describe('hide fields in request', () => {
-    const SKIP: false = false
-    const req = {
-        category: {
-            a: 1,
-            b: SKIP,
-            c: false as const,
-        },
-    }
-    const z: FieldsSelection<SRC, typeof req> = {} as any
-    // test(
-    //     'cannot access falsy fields',
-    //     dontExecute(() => {
-    //         z.category.a
-    //         // @ts-expect-error inaccessible
-    //         z.category.b
-    //         // @ts-expect-error inaccessible
-    //         z.category.c
-    //     }),
-    // )
+  const SKIP: false = false
+  const req = {
+    category: {
+      a: 1,
+      b: SKIP,
+      c: false as const,
+    },
+  }
+  const z: FieldsSelection<SRC, typeof req> = {} as any
+  // test(
+  //     'cannot access falsy fields',
+  //     dontExecute(() => {
+  //         z.category.a
+  //         // @ts-expect-error inaccessible
+  //         z.category.b
+  //         // @ts-expect-error inaccessible
+  //         z.category.c
+  //     }),
+  // )
 })
 
 describe('arrays', () => {
-    const req = {
-        list: {
-            a: 1,
-            x: 1,
-            optional: 1,
+  const req = {
+    list: {
+      a: 1,
+      x: 1,
+      optional: 1,
+    },
+    nested: {
+      __args: { x: 1 },
+      __scalar: 1,
+      list: {
+        edges: {
+          x: 1,
         },
-        nested: {
-            __args: { x: 1 },
-            __scalar: 1,
-            list: {
-                edges: {
-                    x: 1,
-                },
-            },
-        },
-        argumentSyntax: {
-            list: {
-                x: 1,
-                optional: 1,
-            },
-        },
-    }
-    const z: FieldsSelection<SRC, typeof req> = {} as any
-    test(
-        'list',
-        dontExecute(() => {
-            z.list[0].a.charCodeAt
-            z.list[0].x.toFixed
-        }),
-    )
-    test(
-        'nested',
-        dontExecute(() => {
-            z.nested?.list?.[0]?.edges?.[0].x?.toFixed
-        }),
-    )
-    test(
-        'maintain optionals',
-        dontExecute(() => {
-            // @ts-expect-error optional
-            z.list[0].optional.bold
-            z.list[0].optional?.bold
-        }),
-    )
-    test(
-        'args syntax',
-        dontExecute(() => {
-            z.argumentSyntax.list[0].x
-            z.argumentSyntax.list[0].optional?.charAt
-            // @ts-expect-error optional
-            z.argumentSyntax.list[0].optional.charAt
-        }),
-    )
+      },
+    },
+    argumentSyntax: {
+      list: {
+        x: 1,
+        optional: 1,
+      },
+    },
+  }
+  const z: FieldsSelection<SRC, typeof req> = {} as any
+  test(
+    'list',
+    dontExecute(() => {
+      z.list?.[0].a?.charCodeAt
+      z.list?.[0].x?.toFixed
+    }),
+  )
+  test(
+    'nested',
+    dontExecute(() => {
+      z.nested?.list?.[0]?.edges?.[0].x?.toFixed
+    }),
+  )
+  test(
+    'maintain optionals',
+    dontExecute(() => {
+      // @ts-expect-error optional
+      z.list[0].optional.bold
+      z.list?.[0].optional?.bold
+    }),
+  )
+  test(
+    'args syntax',
+    dontExecute(() => {
+      z.argumentSyntax?.list?.[0].x
+      z.argumentSyntax?.list?.[0].optional?.charAt
+      // @ts-expect-error optional
+      z.argumentSyntax.list[0].optional.charAt
+    }),
+  )
 })
 
 describe('literals unions', () => {
-    const req = {
-        literalsUnion: 1,
-    }
-    const z: FieldsSelection<SRC, typeof req> = {} as any
-    test(
-        'literals',
-        dontExecute(() => {
-            z.literalsUnion.blink
-            z.literalsUnion === 'a'
-            z.literalsUnion === 'b'
-            // @ts-expect-error
-            z.literalsUnion === 'x'
-        }),
-    )
+  const req = {
+    literalsUnion: 1,
+  }
+  const z: FieldsSelection<SRC, typeof req> = {} as any
+  test(
+    'literals',
+    dontExecute(() => {
+      z.literalsUnion?.blink
+      z.literalsUnion === 'a'
+      z.literalsUnion === 'b'
+      // @ts-expect-error
+      z.literalsUnion === 'x'
+    }),
+  )
 })
 
 describe('literals unions', () => {
-    const req = {
-        nullableField: {
-            x: 1,
-            optional: 1,
-        },
-    }
-    const z: FieldsSelection<SRC, typeof req> = {} as any
-    test(
-        'accessible',
-        dontExecute(() => {
-            z.nullableField?.x
-            z.nullableField?.optional?.big
-            // @ts-expect-error optional
-            z.nullableField.optional.big
-        }),
-    )
+  const req = {
+    nullableField: {
+      x: 1,
+      optional: 1,
+    },
+  }
+  const z: FieldsSelection<SRC, typeof req> = {} as any
+  test(
+    'accessible',
+    dontExecute(() => {
+      z.nullableField?.x
+      z.nullableField?.optional?.big
+      // @ts-expect-error optional
+      z.nullableField.optional.big
+    }),
+  )
 })
 
 test(
-    'complex optional type with array',
-    dontExecute(() => {
-        interface ForkConnection {
-            edges?: (ForkEdge | undefined)[]
-            __typename?: 'ForkConnection'
-        }
+  'complex optional type with array',
+  dontExecute(() => {
+    interface ForkConnection {
+      edges?: (ForkEdge | undefined)[]
+      __typename?: 'ForkConnection'
+    }
 
-        interface ForkEdge {
-            cursor?: string
-            node?: { x: string; y: string }
-            nodes?: { x?: string; y?: string }[]
-            __typename?: 'ForkEdge'
-        }
+    interface ForkEdge {
+      cursor?: string
+      node?: { x: string; y: string }
+      nodes?: { x?: string; y?: string }[]
+      __typename?: 'ForkEdge'
+    }
 
-        // issue
-        type X = FieldsSelection<
-            ForkConnection | undefined,
-            {
-                edges?: {
-                    node: {
-                        x: 1
-                    }
-                    nodes: {
-                        __scalar: 1
-                    }
-                }
-            }
-        >
-        const x: X = {} as any
-        x?.edges?.[0]?.node?.x?.toLocaleLowerCase
-        // @ts-expect-error not present
-        x?.edges?.[0]?.node?.y?.toLocaleLowerCase
-        x?.edges?.[0]?.nodes?.[0].x?.toLocaleLowerCase
-        x?.edges?.[0]?.nodes?.[0].y?.toLocaleLowerCase
-    }),
+    // issue
+    type X = FieldsSelection<
+      ForkConnection | undefined,
+      {
+        edges?: {
+          node: {
+            x: 1
+          }
+          nodes: {
+            __scalar: 1
+          }
+        }
+      }
+    >
+    const x: X = {} as any
+    x?.edges?.[0]?.node?.x?.toLocaleLowerCase
+    // @ts-expect-error not present
+    x?.edges?.[0]?.node?.y?.toLocaleLowerCase
+    x?.edges?.[0]?.nodes?.[0].x?.toLocaleLowerCase
+    x?.edges?.[0]?.nodes?.[0].y?.toLocaleLowerCase
+  }),
 )
 
 ///////////////////////////////////// unions
@@ -598,12 +599,12 @@ test(
 // }
 
 function dontExecute(f: any) {
-    return () => {}
+  return () => {}
 }
 
 type Impossible<K extends keyof any> = {
-    [P in K]: never
+  [P in K]: never
 }
 
 type NoExtraProperties<T, U extends T = T> = U &
-    Impossible<Exclude<keyof U, keyof T>>
+  Impossible<Exclude<keyof U, keyof T>>


### PR DESCRIPTION
When fields are nullable, we end up trying to use FieldSelection with a first type param that extends null, and it causes a problem that makes anything beyond that field to be inferred as `any`.

Check the isolated issue on following Codesandbox:

> Go to the end of the file and check the types of `withIssue` and `fixed`

https://codesandbox.io/p/sandbox/solitary-morning-jwkt3k?file=%2Fusage.ts%3A33%2C63