### PR TITLE
fix weird turbopack behavior

### DIFF
--- a/cli/src/runtime/fetcher.ts
+++ b/cli/src/runtime/fetcher.ts
@@ -29,33 +29,32 @@ export const createFetcher = ({
     if (!url && !fetcher) {
         throw new Error('url or fetcher is required')
     }
-    if (!fetcher) {
-        fetcher = async (body) => {
-            let headersObject =
-                typeof headers == 'function' ? await headers() : headers
-            headersObject = headersObject || {}
-            if (typeof fetch === 'undefined' && !_fetch) {
-                throw new Error(
-                    'Global `fetch` function is not available, pass a fetch polyfill to Genql `createClient`',
-                )
-            }
-            let fetchImpl = _fetch || fetch
-            const res = await fetchImpl(url!, {
-                headers: {
-                    'Content-Type': 'application/json',
-                    ...headersObject,
-                },
-                method: 'POST',
-                body: JSON.stringify(body),
-                ...rest,
-            })
-            if (!res.ok) {
-                throw new Error(`${res.statusText}: ${await res.text()}`)
-            }
-            const json = await res.json()
-            return json
+
+    fetcher = fetcher || (async (body) => {
+        let headersObject =
+            typeof headers == 'function' ? await headers() : headers
+        headersObject = headersObject || {}
+        if (typeof fetch === 'undefined' && !_fetch) {
+            throw new Error(
+                'Global `fetch` function is not available, pass a fetch polyfill to Genql `createClient`',
+            )
         }
-    }
+        let fetchImpl = _fetch || fetch
+        const res = await fetchImpl(url!, {
+            headers: {
+                'Content-Type': 'application/json',
+                ...headersObject,
+            },
+            method: 'POST',
+            body: JSON.stringify(body),
+            ...rest,
+        })
+        if (!res.ok) {
+            throw new Error(`${res.statusText}: ${await res.text()}`)
+        }
+        const json = await res.json()
+        return json
+    })
 
     if (!batch) {
         return async (body) => {


### PR DESCRIPTION
With Next.js + Turbopack (`next --turbo`), genql throws, oddly. This seems like a bug in Turbopack, but I figured, because it's such a simple fix, we could include it here.

<img width="999" alt="CleanShot 2024-02-01 at 21 23 16 png" src="https://github.com/remorses/genql/assets/40034115/b2d659ef-5f3f-44ad-93bb-32553e13b116">

Wanted to add a codesandbox that reproduces this, but codesandbox is not booting up for me... so @remorses , sent you a DM with a more thorough explanation.