### PR TITLE
Fix issue in typeSelection.ts when handling nullable non-scalars

### DIFF
--- a/cli/src/runtime/typeSelection.ts
+++ b/cli/src/runtime/typeSelection.ts
@@ -24,12 +24,15 @@ export type FieldsSelection<SRC extends Anify<DST> | undefined, DST> = {
         : never
     __scalar: Handle__scalar<SRC, DST>
     never: never
+    null: null
 }[DST extends Nil
     ? 'never'
     : DST extends false | 0
     ? 'never'
     : SRC extends Scalar
     ? 'scalar'
+    : SRC extends null
+    ? 'null'
     : SRC extends any[]
     ? 'array'
     : SRC extends { __isUnion?: any }
@@ -73,9 +76,9 @@ type Handle__scalar<SRC extends Anify<DST>, DST> = SRC extends Nil
                   ? never
                   : Key extends FieldsToRemove
                   ? never
-                  : SRC[Key] extends Scalar
-                  ? Key
                   : Key extends keyof DST
+                  ? (DST[Key] extends false ? never : Key)
+                  : SRC[Key] extends Scalar | null
                   ? Key
                   : never
           }[keyof SRC]
@@ -85,7 +88,7 @@ type Handle__isUnion<SRC extends Anify<DST>, DST> = SRC extends Nil
     ? never
     : Omit<SRC, FieldsToRemove> // just return the union type
 
-type Scalar = string | number | Date | boolean | null | undefined
+type Scalar = string | number | Date | boolean | undefined
 
 type Anify<T> = { [P in keyof T]?: any }
 


### PR DESCRIPTION
When using this library, I notices some strange issues with the output types when relations were not marked as required.

Will try to provide a full example of a schema plus the broken typings the unmodified / modified variants generate later if required.