### PR TITLE
fix: sync fetch errors were not passed back to query requests when batching

### DIFF
--- a/cli/src/runtime/batcher.ts
+++ b/cli/src/runtime/batcher.ts
@@ -45,8 +45,13 @@ function dispatchQueueBatch(client: QueryBatcher, queue: Queue): void {
     if (batchedQuery.length === 1) {
         batchedQuery = batchedQuery[0]
     }
-
-    client.fetcher(batchedQuery).then((responses: any) => {
+    (() => {
+        try {
+            return client.fetcher(batchedQuery);
+        } catch(e) {
+            return Promise.reject(e);
+        }
+    })().then((responses: any) => {
         if (queue.length === 1 && !Array.isArray(responses)) {
             if (responses.errors && responses.errors.length) {
                 queue[0].reject(
@@ -71,6 +76,11 @@ function dispatchQueueBatch(client: QueryBatcher, queue: Queue): void {
             }
         }
     })
+    .catch((e) => {
+        for (let i = 0; i < queue.length; i++) {
+            queue[i].reject(e)
+        }
+    });
 }
 
 /**


### PR DESCRIPTION
Fetch can throw a synchronous error in some circumstances such as if a DNS lookup fails. These errors were not being passed back to client.query requests if batching was enabled.

If you uncomment implementation the new test i just added hangs.