### PR TITLE
Update rimraf to a non-deprecated version but that still supports Node18

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -46,7 +46,7 @@
         "@types/mkdirp": "^1.0.2",
         "@types/node": "^18.11.9",
         "@types/prettier": "^2.7.1",
-        "@types/rimraf": "^3.0.2",
+        "@types/rimraf": "^4.0.5",
         "@types/yargs": "^15.0.5",
         "common-tags": "^1.8.2",
         "dotenv": "^16.0.3",
@@ -67,7 +67,7 @@
         "native-fetch": "^4.0.2",
         "prettier": "^2.8.0",
         "qs": "^6.11.0",
-        "rimraf": "^2.6.3",
+        "rimraf": "^4.4.1",
         "undici": "^5.22.0",
         "yargs": "^15.3.1"
     },

--- a/cli/src/helpers/files.ts
+++ b/cli/src/helpers/files.ts
@@ -1,30 +1,23 @@
-import { promises as fs } from 'fs'
-import mkdirp from 'mkdirp'
-import { resolve } from 'path'
-import rimraf from 'rimraf'
+import { promises as fs } from "fs";
+import mkdirp from "mkdirp";
+import { resolve } from "path";
+import { rimraf } from "rimraf";
 
 export const ensurePath = async (path: string[], clear: boolean = false) => {
-    if (clear)
-        await new Promise((rs, rj) => {
-            rimraf(resolve(...path), (err) => {
-                if (err) rj(err)
-                else rs(undefined)
-            })
-        })
-
-    await mkdirp(resolve(...path))
-}
+    if (clear) await rimraf(resolve(...path));
+    await mkdirp(resolve(...path));
+};
 
 export const readFileFromPath = (path: string[]) =>
-    fs.readFile(resolve(...path)).then((b) => b.toString())
+    fs.readFile(resolve(...path)).then((b) => b.toString());
 
 export const writeFileToPath = async (path: string[], content: string) => {
-    const folder = resolve(...path, '..')
-    await fs.mkdir(folder, { recursive: true })
-    await fs.writeFile(resolve(...path), content)
-}
+    const folder = resolve(...path, "..");
+    await fs.mkdir(folder, { recursive: true });
+    await fs.writeFile(resolve(...path), content);
+};
 
 export const readFilesAndConcat = (files: string[]) =>
     Promise.all(files.map((file) => readFileFromPath([file]))).then(
-        (contents) => contents.join('\n'),
-    )
+        (contents) => contents.join("\n")
+    );


### PR DESCRIPTION
I noticed the rimraf version was deprecated and using callbacks. Updated to the latest version that still supports node18.

I don't know how to update the yarn.lock. 

Context: https://github.com/isaacs/rimraf/commit/9b2a2b13e79516794fc910aa7ca3e37563c777cf#r144765941