### PR TITLE
cli: add blank after nocheck directive to indicate whole file

### DIFF
--- a/cli/src/tasks/clientTasks.ts
+++ b/cli/src/tasks/clientTasks.ts
@@ -54,7 +54,8 @@ export const clientTasks = (config: Config): ListrTask[] => {
                         path.resolve(runtimeFolderPath, file),
                         'utf-8',
                     )
-                    contents = '// @ts-nocheck\n' + contents
+                    // extra newline makes clear this is for the file
+                    contents = '// @ts-nocheck\n\n' + contents
                     await fsx.writeFile(
                         path.resolve(output, 'runtime', file),
                         contents,


### PR DESCRIPTION
If there's not a blank line between the topmost import and the `@ts-nocheck` directive, import sorting tools in formatters like biome.js may not be able to discern whether the directive is for the file or just the first import.

For example, in _batcher.ts_ we have these imports:
```ts
// @ts-nocheck
import type { GraphqlOperation } from './generateGraphqlOperation';
import { GenqlError } from './error';
```

When biomejs sorts this, it's not clear that the directive is for the file, so we end up with this (which has type errors):
```ts
import { GenqlError } from './error';
// @ts-nocheck
import type { GraphqlOperation } from './generateGraphqlOperation';
```

This change will add an extra blank line, so the result is this (directive position will be preserved):
```ts
// @ts-nocheck

import type { GraphqlOperation } from './generateGraphqlOperation';
import { GenqlError } from './error';
```